### PR TITLE
Fluent API fixes.

### DIFF
--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/Common.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/Common.java
@@ -1628,6 +1628,7 @@ public abstract class Common<T> implements Comparable<T> {
    * @since 3.1.0
    */
   public T withEntryDateTime(DT value) {
+    setEntryDateTime(value);
     return (T) this;
   }
 
@@ -1791,6 +1792,7 @@ public abstract class Common<T> implements Comparable<T> {
    * @since 3.1.0
    */
   public T withSecurityClass(SecurityClass value) {
+    setSecurityClass(value);
     return (T) this;
   }
 
@@ -1901,6 +1903,7 @@ public abstract class Common<T> implements Comparable<T> {
    * @since 3.1.0
    */
   public T withCls(ListCCL value) {
+    setCls(value);
     return (T) this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/SSRequest.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/SSRequest.java
@@ -2526,6 +2526,7 @@ public class SSRequest extends Common<SSRequest> {
    * @since 3.1.0
    */
   public SSRequest withTrunking(Trunking value) {
+    setTrunking(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/CircuitRemarks.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/CircuitRemarks.java
@@ -441,6 +441,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -453,6 +454,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -529,6 +531,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -542,6 +545,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -553,6 +557,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -569,6 +574,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -582,6 +588,7 @@ public class CircuitRemarks {
    * @since 3.1.0
    */
   public CircuitRemarks withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DCSTrunk.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DCSTrunk.java
@@ -452,6 +452,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -464,6 +465,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -538,6 +540,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -551,6 +554,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -562,6 +566,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -578,6 +583,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -591,6 +597,7 @@ public class DCSTrunk {
    * @since 3.1.0
    */
   public DCSTrunk withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DetailedFunction.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DetailedFunction.java
@@ -435,6 +435,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withValue(ListUFN value) {
+    setValue(value);
     return this;
   }
 
@@ -447,6 +448,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -521,6 +523,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -534,6 +537,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -545,6 +549,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -561,6 +566,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -574,6 +580,7 @@ public class DetailedFunction {
    * @since 3.1.0
    */
   public DetailedFunction withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DocketNum.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/DocketNum.java
@@ -437,6 +437,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -449,6 +450,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -523,6 +525,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -536,6 +539,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -547,6 +551,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -563,6 +568,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -576,6 +582,7 @@ public class DocketNum {
    * @since 3.1.0
    */
   public DocketNum withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/HostDocketNum.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/HostDocketNum.java
@@ -438,6 +438,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -450,6 +451,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -524,6 +526,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -537,6 +540,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -548,6 +552,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -564,6 +569,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -577,6 +583,7 @@ public class HostDocketNum {
    * @since 3.1.0
    */
   public HostDocketNum withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/OffTheShelfEquipment.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/assignment/OffTheShelfEquipment.java
@@ -447,6 +447,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -459,6 +460,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -533,6 +535,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -546,6 +549,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -557,6 +561,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -573,6 +578,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -586,6 +592,7 @@ public class OffTheShelfEquipment {
    * @since 3.1.0
    */
   public OffTheShelfEquipment withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/common/Remarks.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/common/Remarks.java
@@ -183,6 +183,7 @@ public class Remarks {
    * @since 3.1.0
    */
   public Remarks withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -195,6 +196,7 @@ public class Remarks {
    * @since 3.1.0
    */
   public Remarks withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -209,6 +211,7 @@ public class Remarks {
    * @since 3.1.0
    */
   public Remarks withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Ellipse.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Ellipse.java
@@ -645,6 +645,7 @@ public class Ellipse {
    * @since 3.1.0
    */
   public Ellipse withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Point.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Point.java
@@ -538,6 +538,7 @@ public class Point {
    * @since 3.1.0
    */
   public Point withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Polygon.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/Polygon.java
@@ -81,7 +81,7 @@ public class Polygon {
   /**
    * idx - Index (Required)
    * <p>
-   * A unique integer index for the current ellipse within the Location.
+   * A unique integer index for the current polygon within the Location.
    * <p>
    * Format is UN(6)
    * <p>
@@ -115,7 +115,7 @@ public class Polygon {
   }
 
   /**
-   * Determine if the Excluded is configured.
+   * Determine if the Excluded property is configured.
    * <p>
    * If configured this method also inspects the {@link TString} wrapped value.
    * <p>
@@ -126,8 +126,10 @@ public class Polygon {
   }
 
   /**
-   * Get .
+   * Get the minimum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @return a {@link Altitude} instance
    * @since 3.1.0
    */
@@ -136,8 +138,10 @@ public class Polygon {
   }
 
   /**
-   * Set .
+   * Set the minimum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @param value a {@link Altitude} instance
    * @since 3.1.0
    */
@@ -155,8 +159,10 @@ public class Polygon {
   }
 
   /**
-   * Get .
+   * Get the maximum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @return a {@link Altitude} instance
    * @since 3.1.0
    */
@@ -165,8 +171,10 @@ public class Polygon {
   }
 
   /**
-   * Set .
+   * Set the maximum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @param value a {@link Altitude} instance
    * @since 3.1.0
    */
@@ -190,7 +198,7 @@ public class Polygon {
    * that represent a vertex of the polygon. Polygon points are described in a
    * clockwise direction. If the last point is different from the first point,
    * it is assumed that they are connected to complete the boundary of the
-   * polygon..
+   * polygon.
    * <p>
    * @return a {@link PolygonPoint} instance
    * @since 3.1.0
@@ -219,7 +227,7 @@ public class Polygon {
   }
 
   /**
-   * Get a unique integer index for the current ellipse within the Location..
+   * Get a unique integer index for the current polygon within the Location.
    * <p>
    * @return a {@link BigInteger} instance
    * @since 3.1.0
@@ -229,7 +237,7 @@ public class Polygon {
   }
 
   /**
-   * Set a unique integer index for the current ellipse within the Location..
+   * Set a unique integer index for the current polygon within the Location.
    * <p>
    * @param value a {@link BigInteger} instance
    * @since 3.1.0
@@ -262,8 +270,10 @@ public class Polygon {
   }
 
   /**
-   * Set
+   * Set the minimum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @param value An instances of type {@link Double}.
    * @return The current Polygon object instance.
    * @since 3.1.0
@@ -274,8 +284,10 @@ public class Polygon {
   }
 
   /**
-   * Set
+   * Set the maximum or nominal height of the point above the terrain.
    * <p>
+   * Note that this is height above ground level (AGL).
+   *
    * @param value An instances of type {@link Double}.
    * @return The current Polygon object instance.
    * @since 3.1.0
@@ -286,7 +298,7 @@ public class Polygon {
   }
 
   /**
-   * Set the PolygonPoint
+   * Set the PolygonPoint.
    * <p>
    * Complex element PolygonPoint contains the coordinates (WGS 84) of point(s)
    * that represent a vertex of the polygon. Polygon points are described in a
@@ -306,7 +318,7 @@ public class Polygon {
   }
 
   /**
-   * Set the PolygonPoint
+   * Set the PolygonPoint.
    * <p>
    * Complex element PolygonPoint contains the coordinates (WGS 84) of point(s)
    * that represent a vertex of the polygon. Polygon points are described in a
@@ -326,13 +338,14 @@ public class Polygon {
   }
 
   /**
-   * Set a unique integer index for the current ellipse within the Location.
+   * Set a unique integer index for the current polygon within the Location.
    * <p>
    * @param value An instances of type {@link BigInteger}.
    * @return The current Polygon object instance.
    * @since 3.1.0
    */
   public Polygon withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/PolygonPoint.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/location/PolygonPoint.java
@@ -166,7 +166,7 @@ public class PolygonPoint {
 
   /**
    * Get a unique, sequenced, index for each point describing the current
-   * polygon..
+   * polygon.
    * <p>
    * @return a {@link BigInteger} instance
    * @since 3.1.0
@@ -177,7 +177,7 @@ public class PolygonPoint {
 
   /**
    * Set a unique, sequenced, index for each point describing the current
-   * polygon..
+   * polygon.
    * <p>
    * @param value a {@link BigInteger} instance
    * @since 3.1.0
@@ -262,6 +262,7 @@ public class PolygonPoint {
    * @since 3.1.0
    */
   public PolygonPoint withSequence(BigInteger value) {
+    setSequence(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/multiple/ConfigFreq.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/multiple/ConfigFreq.java
@@ -604,6 +604,7 @@ public class ConfigFreq {
    * @since 3.1.0
    */
   public ConfigFreq withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/multiple/RxModeRef.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/multiple/RxModeRef.java
@@ -437,6 +437,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -449,6 +450,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -523,6 +525,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -536,6 +539,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -547,6 +551,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withRecommendedValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -563,6 +568,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -576,6 +582,7 @@ public class RxModeRef {
    * @since 3.1.0
    */
   public RxModeRef withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/Curve.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/Curve.java
@@ -619,6 +619,7 @@ public class Curve {
    * @since 3.1.0
    */
   public Curve withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/EmsClass.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/EmsClass.java
@@ -595,6 +595,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -607,6 +608,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withExplainInformationTypeX(String value) {
+    setExplainInformationTypeX(value);
     return this;
   }
 
@@ -619,6 +621,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withExplainModulationTypeX(String value) {
+    setExplainModulationTypeX(value);
     return this;
   }
 
@@ -631,6 +634,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withExplainNatureOfSignalX(String value) {
+    setExplainNatureOfSignalX(value);
     return this;
   }
 
@@ -643,6 +647,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -717,6 +722,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -730,6 +736,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -741,6 +748,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -757,6 +765,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -770,6 +779,7 @@ public class EmsClass {
    * @since 3.1.0
    */
   public EmsClass withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/Installation.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/Installation.java
@@ -444,6 +444,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -456,6 +457,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -530,6 +532,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -543,6 +546,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -554,6 +558,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -570,6 +575,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -583,6 +589,7 @@ public class Installation {
    * @since 3.1.0
    */
   public Installation withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/RxMode.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/receiver/RxMode.java
@@ -2073,6 +2073,7 @@ public class RxMode {
    * @since 3.1.0
    */
   public RxMode withSpreadSpectrum(SpreadSpectrum value) {
+    setSpreadSpectrum(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/satellite/ServiceArea.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/satellite/ServiceArea.java
@@ -438,6 +438,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withValue(ListCAO value) {
+    setValue(value);
     return this;
   }
 
@@ -450,6 +451,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -524,6 +526,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -537,6 +540,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -548,6 +552,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -564,6 +569,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -577,6 +583,7 @@ public class ServiceArea {
    * @since 3.1.0
    */
   public ServiceArea withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/ssreply/Comment.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/ssreply/Comment.java
@@ -488,6 +488,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withValue(String value) {
+    setValue(value);
     return this;
   }
 
@@ -502,6 +503,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 
@@ -514,6 +516,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -588,6 +591,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -601,6 +605,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -612,6 +617,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -628,6 +634,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -641,6 +648,7 @@ public class Comment {
    * @since 3.1.0
    */
   public Comment withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/ssrequest/HostNation.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/ssrequest/HostNation.java
@@ -446,6 +446,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withValue(ListCAO value) {
+    setValue(value);
     return this;
   }
 
@@ -458,6 +459,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -532,6 +534,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -545,6 +548,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -556,6 +560,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -572,6 +577,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -585,6 +591,7 @@ public class HostNation {
    * @since 3.1.0
    */
   public HostNation withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Administration.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Administration.java
@@ -437,6 +437,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withValue(ListCAO value) {
+    setValue(value);
     return this;
   }
 
@@ -449,6 +450,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -523,6 +525,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -536,6 +539,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -547,6 +551,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -563,6 +568,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -576,6 +582,7 @@ public class Administration {
    * @since 3.1.0
    */
   public Administration withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Country.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Country.java
@@ -444,6 +444,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withValue(ListCAO value) {
+    setValue(value);
     return this;
   }
 
@@ -456,6 +457,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -530,6 +532,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -543,6 +546,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -554,6 +558,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -570,6 +575,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -583,6 +589,7 @@ public class Country {
    * @since 3.1.0
    */
   public Country withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Footnote.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/Footnote.java
@@ -293,6 +293,7 @@ public class Footnote {
    * @since 3.1.0
    */
   public Footnote withIdx(BigInteger value) {
+    setIdx(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/StnClass.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/toa/StnClass.java
@@ -437,6 +437,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withValue(ListUSC value) {
+    setValue(value);
     return this;
   }
 
@@ -449,6 +450,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withCls(ListCCL value) {
+    setCls(value);
     return this;
   }
 
@@ -523,6 +525,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withLegacyReleasability(String value) {
+    setLegacyReleasability(value);
     return this;
   }
 
@@ -536,6 +539,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withQuality(String value) {
+    setQuality(value);
     return this;
   }
 
@@ -547,6 +551,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withRecommendedValue(String value) {
+    setRecommendedValue(value);
     return this;
   }
 
@@ -563,6 +568,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withIdref(String value) {
+    setIdref(value);
     return this;
   }
 
@@ -576,6 +582,7 @@ public class StnClass {
    * @since 3.1.0
    */
   public StnClass withAvailability(String value) {
+    setAvailability(value);
     return this;
   }
 

--- a/src/main/java/us/gov/dod/standard/ssrf/_3_1/transmitter/TxMode.java
+++ b/src/main/java/us/gov/dod/standard/ssrf/_3_1/transmitter/TxMode.java
@@ -2592,6 +2592,7 @@ public class TxMode {
    * @since 3.1.0
    */
   public TxMode withSpreadSpectrum(SpreadSpectrum value) {
+    setSpreadSpectrum(value);
     return this;
   }
 


### PR DESCRIPTION
Noted a few of the fluent API methods (e.g. `.withCls()`) didn't appear to have any effect. Looks like the associated setters were missed.

There are minor API documentation fixes for this - have more for another PR, but the javadoc changes don't make this PR much more complicated to review, so added whole files rather than trying to split it out.